### PR TITLE
Add support for BIP39 passphrase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,8 @@ export default class HDKeyring implements Keyring<SerializedHDKeyring> {
   }
 
   static deserialize(obj: SerializedHDKeyring): HDKeyring {
-    const { version, keyringType, mnemonic, path, addressIndex, passphrase } = obj
+    const { version, keyringType, mnemonic, path, addressIndex, passphrase } =
+      obj
     if (version !== 1) {
       throw new Error(`Unknown serialization version ${obj.version}`)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export default class HDKeyring implements Keyring<SerializedHDKeyring> {
 
     this.#mnemonic = mnemonic
 
-    const passphrase = hdOptions.passphrase || ""
+    const passphrase = hdOptions.passphrase ?? ""
 
     this.#passphrase = passphrase
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ const defaultOptions = {
   path: "m/44'/60'/0'/0",
   strength: 256,
   mnemonic: null,
-  passphrase: "",
+  passphrase: null,
 }
 
 export type SerializedHDKeyring = {
@@ -36,7 +36,6 @@ export type SerializedHDKeyring = {
   path: string
   keyringType: string
   addressIndex: number
-  passphrase: string
 }
 
 export interface Keyring<T> {
@@ -78,8 +77,6 @@ export default class HDKeyring implements Keyring<SerializedHDKeyring> {
 
   #mnemonic: string
 
-  #passphrase: string
-
   constructor(options: Options = {}) {
     const hdOptions: Required<Options> = {
       ...defaultOptions,
@@ -97,8 +94,6 @@ export default class HDKeyring implements Keyring<SerializedHDKeyring> {
     this.#mnemonic = mnemonic
 
     const passphrase = hdOptions.passphrase ?? ""
-
-    this.#passphrase = passphrase
 
     this.path = hdOptions.path
     this.#hdNode = HDNode.fromMnemonic(mnemonic, passphrase, "en").derivePath(
@@ -118,7 +113,6 @@ export default class HDKeyring implements Keyring<SerializedHDKeyring> {
       keyringType: HDKeyring.type,
       path: this.path,
       addressIndex: this.#addressIndex,
-      passphrase: this.#passphrase,
     }
   }
 
@@ -126,9 +120,8 @@ export default class HDKeyring implements Keyring<SerializedHDKeyring> {
     return this.serializeSync()
   }
 
-  static deserialize(obj: SerializedHDKeyring): HDKeyring {
-    const { version, keyringType, mnemonic, path, addressIndex, passphrase } =
-      obj
+  static deserialize(obj: SerializedHDKeyring, passphrase?: string): HDKeyring {
+    const { version, keyringType, mnemonic, path, addressIndex } = obj
     if (version !== 1) {
       throw new Error(`Unknown serialization version ${obj.version}`)
     }

--- a/test/keyring.test.ts
+++ b/test/keyring.test.ts
@@ -278,6 +278,9 @@ describe("HDKeyring", () => {
         expect(await keyring1.getAddresses()).not.toStrictEqual(
           await keyring2.getAddresses()
         )
+        expect(await keyring1.getAddresses()).not.toStrictEqual(
+          await keyring3.getAddresses()
+        )
         expect(await keyring2.getAddresses()).not.toStrictEqual(
           await keyring3.getAddresses()
         )

--- a/test/keyring.test.ts
+++ b/test/keyring.test.ts
@@ -52,10 +52,7 @@ const validDerivations = [
   },
 ]
 
-const testPassphrases = [
-  "super_secret",
-  "1234"
-]
+const testPassphrases = ["super_secret", "1234"]
 
 const twelveOrMoreWordMnemonics = validMnemonics.filter(
   (m) => m.split(" ").length >= 12

--- a/test/keyring.test.ts
+++ b/test/keyring.test.ts
@@ -110,6 +110,25 @@ describe("HDKeyring", () => {
       })
     )
   })
+  it("deserializes with passphrase after serializing", async () => {
+    await Promise.all(
+      twelveOrMoreWordMnemonics.map(async (m) => {
+        const keyring = new HDKeyring({
+          mnemonic: m,
+          passphrase: testPassphrases[0],
+        })
+        const id1 = keyring.id
+
+        const serialized = await keyring.serialize()
+        const deserialized = HDKeyring.deserialize(
+          serialized,
+          testPassphrases[0]
+        )
+
+        expect(id1).toBe(deserialized.id)
+      })
+    )
+  })
   it("fails to deserialize different versions", async () => {
     await Promise.all(
       twelveOrMoreWordMnemonics.map(async (m) => {


### PR DESCRIPTION
Allow [BIP39](https://en.bitcoin.it/wiki/BIP_0039#From_mnemonic_to_seed) passphrase usage.

This is needed for tallycash/extension#1022

This can be merged and released without the code in the aforementioned PR being present without breaking the extension.

This will allow loading keys with passphrases for users that choose to use them,
but will *not* store those passphrases; instead, they are accepted at deserialization
time to complete the deserialization successfully.