### PR TITLE
Pin @ethersproject/wallet to 5.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ethersproject/abstract-provider": "^5.4.0",
     "@ethersproject/abstract-signer": "^5.4.0",
     "@ethersproject/hdnode": "^5.4.0",
-    "@ethersproject/wallet": "^5.4.0",
+    "@ethersproject/wallet": "5.4.0",
     "bip39": "^3.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,7 +1205,7 @@
     "@ethersproject/rlp" "^5.4.0"
     "@ethersproject/signing-key" "^5.4.0"
 
-"@ethersproject/wallet@^5.4.0":
+"@ethersproject/wallet@5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.4.0.tgz#fa5b59830b42e9be56eadd45a16a2e0933ad9353"
   integrity sha512-wU29majLjM6AjCjpat21mPPviG+EpK7wY1+jzKD0fg3ui5fgedf2zEu1RDgpfIMsfn8fJHJuzM4zXZ2+hSHaSQ==


### PR DESCRIPTION
Per Least Authority's suggestion in Issue C of the partial extension audit report — we're using an experimental function that might change down the road, and pinning is a good practice.