### PR TITLE
Run CI in pull request context

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  pull_request: {}
+  push:
+    branches:
+    - main
 jobs:
   build:
     name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}


### PR DESCRIPTION
This allows running CI builds for external contributors (with committee
approval), which isn’t possible with push contexts. 

Push context is maintained for main branch otherwise merges won’t run
builds.